### PR TITLE
Fix ipxe script

### DIFF
--- a/ipxe/ws006964.ipxe
+++ b/ipxe/ws006964.ipxe
@@ -1,11 +1,21 @@
 #!ipxe
 
 # Set variables
-set base-url http://archive.ubuntu.com/ubuntu/dists/noble/main/installer-amd64/current/legacy-images/netboot/ubuntu-installer/amd64
-set autoinstall-url https://rampart-aios.github.io/autoinstall/deploy/ro/ws006964
+set autoinstall_url https://rampart-aios.github.io/autoinstall/deploy/ro/ws006964/
+set kernel_url https://github.com/netbootxyz/ubuntu-squash/releases/download/24.04.2-dac09526/
+set ubuntu_iso_url https://releases.ubuntu.com/noble/ubuntu-24.04.2-live-server-amd64.iso
+set netboot_params ip=dhcp url=${ubuntu_iso_url}
+set install_params autoinstall ds=nocloud-net;s=${autoinstall_url}
 
 echo Booting Ubuntu 24.04 installer with autoinstall URL: ${autoinstall-url}
 
-kernel ${base-url}/linux auto=true priority=critical console=ttyS0,115200n8 --- autoinstall ds=nocloud-net;s=${autoinstall-url}/
-initrd ${base-url}/initrd.gz
+imgfree
+kernel ${kernel_url}vmlinuz \
+    root=/dev/ram0 \
+    ramdisk_size=3500000 \
+    cloud-config-url=/dev/null \
+    ${netboot_params} \
+    ${install_params} \
+    initrd=initrd.magic
+initrd ${kernel_url}initrd
 boot

--- a/ipxe/ws006964.ipxe
+++ b/ipxe/ws006964.ipxe
@@ -1,21 +1,32 @@
 #!ipxe
+# This script is intended for Ubuntu Distro
 
-# Set variables
-set autoinstall_url https://rampart-aios.github.io/autoinstall/deploy/ro/ws006964/
-set kernel_url https://github.com/netbootxyz/ubuntu-squash/releases/download/24.04.2-dac09526/
-set ubuntu_iso_url https://releases.ubuntu.com/noble/ubuntu-24.04.2-live-server-amd64.iso
-set netboot_params ip=dhcp url=${ubuntu_iso_url}
-set install_params autoinstall ds=nocloud-net;s=${autoinstall_url}
+# dynamic vars
+set mirror https://releases.ubuntu.com
+set base_dir ubuntu
+set codename noble
+set version 24.04.2
+set os_arch amd64
+set department ro
+set machine ws006964
 
-echo Booting Ubuntu 24.04 installer with autoinstall URL: ${autoinstall-url}
+# static vars
+set kernel_url ${mirror}/${codename}/netboot/${os_arch}
+set ubuntu_iso_url ${mirror}/${codename}/${base_dir}-${version}-live-server-${os_arch}.iso
+set autoinstall_url https://rampart-aios.github.io/autoinstall/deploy/${department}/${machine}
+
+# operation
+echo Booting Ubuntu 24.04 installer...
+echo Kernel URL: ${kernel_url}
+echo Autoinstall URL: ${autoinstall_url}
 
 imgfree
-kernel ${kernel_url}vmlinuz \
+kernel ${kernel_url}/linux \
     root=/dev/ram0 \
     ramdisk_size=3500000 \
     cloud-config-url=/dev/null \
-    ${netboot_params} \
-    ${install_params} \
+    ip=dhcp url=${ubuntu_iso_url} \
+    autoinstall ds=nocloud-net;s=${autoinstall_url}/ \
     initrd=initrd.magic
-initrd ${kernel_url}initrd
+initrd ${kernel_url}/initrd
 boot


### PR DESCRIPTION
Issue
- Current ipxe script but it’s not working due to broken Ubuntu base URL and wrong kernel params.

To test
- Boot using netboot.xyz
- Select Shell
- Execute `chain <URL_TO_CUSTOM_IPXE_SCRIPT>`. The URL is hosted on my local using nginx container.